### PR TITLE
Patch Driver can Create Multiple Activity

### DIFF
--- a/app/Http/Controllers/Admin/ActivityController.php
+++ b/app/Http/Controllers/Admin/ActivityController.php
@@ -304,10 +304,10 @@ class ActivityController extends Controller
   public function showLog(Activity $activity)
   {
     $activityStatus = DB::table('activity_statuses')
-      ->leftJoin('users', 'activity_statuses.created_by', '=', 'users.id')
-      ->leftJoin('people', 'users.person_id', '=', 'people.id')
-      ->leftJoin('model_has_roles', 'users.id', '=', 'model_has_roles.model_id')
-      ->leftJoin('roles', 'roles.id', '=', 'model_has_roles.role_id')
+      ->leftJoin('users', 'activity_statuses.created_by', 'users.id')
+      ->leftJoin('people', 'users.person_id', 'people.id')
+      ->leftJoin('model_has_roles', 'users.id', 'model_has_roles.model_id')
+      ->leftJoin('roles', 'roles.id', 'model_has_roles.role_id')
       ->where('activity_id', $activity->id)
       ->get(['status', 'people.name', 'activity_statuses.created_at', 'roles.name AS role']);
 
@@ -337,16 +337,17 @@ class ActivityController extends Controller
     $q_status = $request->status;
 
     $activities = DB::table('activities')
-      ->leftJoin('users', 'activities.user_id', '=', 'users.id')
-      ->leftJoin('people', 'users.person_id', '=', 'people.id')
+      ->leftJoin('users', 'activities.user_id', 'users.id')
+      ->leftJoin('people', 'users.person_id', 'people.id')
       ->leftJoin('projects', 'people.project_id', 'projects.id')
-      ->leftJoin('activity_statuses', 'activities.activity_status_id', '=', 'activity_statuses.id')
-      ->leftJoin('activity_payments', 'activity_statuses.id', '=', 'activity_payments.activity_status_id')
+      ->leftJoin('activity_statuses', 'activities.activity_status_id', 'activity_statuses.id')
+      ->leftJoin('activity_payments', 'activity_statuses.id', 'activity_payments.activity_status_id')
       ->whereIn('activity_statuses.status', ['pending', 'rejected'])
       ->get(
         [
           'activities.id',
           'activities.departure_date',
+          'activities.type',
           'do_number',
           'people.name',
           'projects.name AS project_name',

--- a/app/Interface/ActivityStatusInterface.php
+++ b/app/Interface/ActivityStatusInterface.php
@@ -4,5 +4,10 @@ namespace App\Interface;
 
 interface ActivityStatusInterface
 {
-	public const DEFAULT_DRIVER_LOCATION = 135;
+	public const STATUS_DRAFT = 'draft';
+	public const STATUS_PENDING = 'pending';
+	public const STATUS_APPROVED = 'approved';
+	public const STATUS_PAID = 'paid';
+	public const STATUS_REJECTED = 'rejected';
+	public const STATUS_CANCEL = 'cancel';
 }

--- a/app/Interface/ResponseCodeInterface.php
+++ b/app/Interface/ResponseCodeInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Interface;
+
+interface ResponseCodeInterface
+{
+	public const ERROR_REDIRECT_BACK = 5000;
+	public const ERROR_REDIRECT_INDEX = 4000;
+}

--- a/public/js/tableConfig.js
+++ b/public/js/tableConfig.js
@@ -18,6 +18,8 @@ document.addEventListener("DOMContentLoaded", function () {
     ],
   });
 
+  if(table.context.length == 0) return;
+
   $.fn.dataTable.Buttons.defaults.dom.button.className =
     "btn btn-outline-primary";
 

--- a/resources/views/admin/finance/acceptance/index.blade.php
+++ b/resources/views/admin/finance/acceptance/index.blade.php
@@ -139,6 +139,7 @@
               <th>Nomor DO</th>
               <th>Nama Pengendara</th>
               <th>Project</th>
+              <th>Jenis Aktivitas</th>
               <th>BBM</th>
               <th>Toll</th>
               <th>Parkir</th>
@@ -162,6 +163,7 @@
                 <td>{{ $activity->do_number }}</td>
                 <td>{{ $activity->name }}</td>
                 <td>{{ $activity->project_name }}</td>
+                <td>{{ $activity->type }}</td>
                 <td>@money($activity->bbm_amount)</td>
                 <td>@money($activity->toll_amount)</td>
                 <td>@money($activity->parking_amount)</td>

--- a/resources/views/layouts/alert-swal.blade.php
+++ b/resources/views/layouts/alert-swal.blade.php
@@ -1,37 +1,37 @@
 <script>
-	function generateSwalPayload(title, message, icon) {
-		 let form = document.createElement("div");
-		 form.innerHTML = message;
-		 return {
-				icon,
-				title,
-				html: true,
-				content: form,
-				confirmButtonText: "Tutup"
-		 }
-	}
+  function generateSwalPayload(title, message, icon) {
+    let form = document.createElement("div");
+    form.innerHTML = message;
+    return {
+      icon,
+      title,
+      html: true,
+      content: form,
+      confirmButtonText: "Tutup"
+    }
+  }
 </script>
 
 @if ($message = Session::get('success-swal'))
-	<script>
-		 swal(generateSwalPayload("Success", `{!! $message !!}`, "success"));
-	</script>
+  <script>
+    Swal.fire(generateSwalPayload("Success", `{!! $message !!}`, "success"));
+  </script>
 @endif
 
 @if ($message = Session::get('error-swal'))
-	<script>
-		 swal(generateSwalPayload("Failed", `{!! $message !!}`, "error"));
-	</script>
+  <script>
+    Swal.fire("Failed", `{!! $message !!}`, "error");
+  </script>
 @endif
 
 @if ($message = Session::get('warning-swal'))
-	<script>
-		 swal(generateSwalPayload("Warning", `{!! $message !!}`, "warning"));
-	</script>
+  <script>
+    Swal.fire(generateSwalPayload("Warning", `{!! $message !!}`, "warning"));
+  </script>
 @endif
 
 @if ($message = Session::get('info-swal-html'))
-	<script>
-		 swal(generateSwalPayload("Info", `{!! $message !!}`, "info"));
-	</script>
+  <script>
+    Swal.fire(generateSwalPayload("Info", `{!! $message !!}`, "info"));
+  </script>
 @endif


### PR DESCRIPTION
1. [Patch] Drivers can create an activity even if they already have a draft activity
2. [Add] Activity Type Column in Acceptance Admin List
3. [Patch] call `Swal.Fire()` instead of `swal()`
4. [Patch] Return when datatable is not found